### PR TITLE
Fix saving images with padding

### DIFF
--- a/DDSReader/DDSReader/DDSImage.cs
+++ b/DDSReader/DDSReader/DDSImage.cs
@@ -23,6 +23,25 @@ namespace DDSReader
             }
         }
 
+        private byte[] TightData()
+        {
+            // Since image sharp can't handle data with line padding in a stride
+            // we create an stripped down array if any padding is detected
+            var tightStride = _image.Width * _image.BitsPerPixel / 8;
+            if (_image.Stride == tightStride)
+            {
+                return _image.Data;
+            }
+
+            byte[] newData = new byte[_image.Height * tightStride];
+            for (int i = 0; i < _image.Height; i++)
+            {
+                Buffer.BlockCopy(_image.Data, i * _image.Stride, newData, i * tightStride, tightStride);
+            }
+
+            return newData;
+        }
+
         public DDSImage(string file)
         {
             _image = Pfim.Pfim.FromFile(file);
@@ -70,7 +89,7 @@ namespace DDSReader
             where T : struct, IPixel<T>
         {
             Image<T> image = SixLabors.ImageSharp.Image.LoadPixelData<T>(
-                _image.Data, _image.Width, _image.Height);
+                TightData(), _image.Width, _image.Height);
             image.Save(file);
         }
 
@@ -132,7 +151,7 @@ namespace DDSReader
             where T : struct, IPixel<T>
         {
             Image<T> image = SixLabors.ImageSharp.Image.LoadPixelData<T>(
-                _image.Data, _image.Width, _image.Height);
+                TightData(), _image.Width, _image.Height);
             image.SaveAsBmp<T>(file);
         }
 
@@ -140,21 +159,21 @@ namespace DDSReader
             where T : struct, IPixel<T>
         {
             Image<T> image = SixLabors.ImageSharp.Image.LoadPixelData<T>(
-                _image.Data, _image.Width, _image.Height);
+                TightData(), _image.Width, _image.Height);
             image.SaveAsGif<T>(file);
         }
         private void SaveAsJpeg<T>(Stream file)
             where T : struct, IPixel<T>
         {
             Image<T> image = SixLabors.ImageSharp.Image.LoadPixelData<T>(
-                _image.Data, _image.Width, _image.Height);
+                TightData(), _image.Width, _image.Height);
             image.SaveAsJpeg<T>(file);
         }
         private void SaveAsPng<T>(Stream file)
             where T : struct, IPixel<T>
         {
             Image<T> image = SixLabors.ImageSharp.Image.LoadPixelData<T>(
-                _image.Data, _image.Width, _image.Height);
+                TightData(), _image.Width, _image.Height);
             image.SaveAsPng<T>(file);
         }
 

--- a/DDSReader/DDSReader/DDSReader.csproj
+++ b/DDSReader/DDSReader/DDSReader.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pfim" Version="0.7.0" />
+    <PackageReference Include="Pfim" Version="0.8.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>


### PR DESCRIPTION
image sharp can't handle data with line padding in a stride (for
instance given a small dds image or a dds image with an odd width /
height, as dds images are block based). The fix is to create a temporary
buffer with the dimensions that image sharp expects and copy over the
required data

I also bumped Pfim to the latest version.